### PR TITLE
Feature/evict action

### DIFF
--- a/src/main/java/no/fintlabs/cache/Cache.java
+++ b/src/main/java/no/fintlabs/cache/Cache.java
@@ -1,7 +1,10 @@
 package no.fintlabs.cache;
 
+import no.fintlabs.cache.cacheObjects.CacheObject;
+
 import java.io.Serializable;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -39,6 +42,8 @@ public interface Cache<T extends Serializable> {
     Optional<T> getLastUpdatedByFilter(int hashCode, Predicate<T> predicate);
 
     void evictOldCacheObjects();
+
+    void evictOldCacheObjects(BiConsumer<String, CacheObject<T>> onEvict);
 
     void setRetentionPeriodInMs(long periodInMs);
 

--- a/src/main/java/no/fintlabs/cache/FintCache.java
+++ b/src/main/java/no/fintlabs/cache/FintCache.java
@@ -197,9 +197,7 @@ public class FintCache<T extends Serializable> implements Cache<T>, Serializable
     @Scheduled(initialDelay = 900000L, fixedDelay = 900000L)
     public void evictOldCacheObjects() {
         if (retentionPeriodInMs <= 0) return;
-        getExpiredEntries().forEach(entrySet ->
-                cacheObjects.remove(entrySet.getKey())
-        );
+        getExpiredEntries().forEach(entrySet -> remove(entrySet.getKey()));
     }
 
     private List<Map.Entry<String, CacheObject<T>>> getExpiredEntries() {

--- a/src/main/java/no/fintlabs/cache/FintCache.java
+++ b/src/main/java/no/fintlabs/cache/FintCache.java
@@ -194,7 +194,6 @@ public class FintCache<T extends Serializable> implements Cache<T>, Serializable
         return cacheObjects.values().stream().mapToLong(CacheObject::getSize).sum();
     }
 
-    @Scheduled(initialDelay = 900000L, fixedDelay = 900000L)
     public void evictOldCacheObjects() {
         if (retentionPeriodInMs <= 0) return;
         getExpiredEntries().forEach(entrySet -> remove(entrySet.getKey()));

--- a/src/test/groovy/no/fintlabs/FintCacheSpec.groovy
+++ b/src/test/groovy/no/fintlabs/FintCacheSpec.groovy
@@ -2,9 +2,11 @@ package no.fintlabs
 
 import no.fintlabs.cache.CacheObjectFactory
 import no.fintlabs.cache.FintCache
+import no.fintlabs.cache.cacheObjects.CacheObject
 import no.fintlabs.cache.packing.PackingTypes
 import spock.lang.Specification
 
+import java.util.function.BiConsumer
 import java.util.stream.Collectors
 
 class FintCacheSpec extends Specification {
@@ -257,6 +259,47 @@ class FintCacheSpec extends Specification {
         !cache.@hashCodesIndex.entries().any { it.value == "victim" }
         !cache.@lastUpdatedIndex.entries().any { it.value == "victim" }
     }
+
+    def "Eviction callback is invoked for each expired entry"() {
+        given:
+        cache.setRetentionPeriodInMs(50)
+
+        cache.put("old1", new TestObject("Denethor"), new int[]{})
+        cache.put("old2", new TestObject("Faramir"), new int[]{})
+        sleep(60)
+
+        cache.put("fresh", new TestObject("Eowyn"), new int[]{})
+
+        def evictedKeys = [] as List<String>
+        BiConsumer<String, CacheObject<TestObject>> callback =
+                { String k, CacheObject<TestObject> v -> evictedKeys << k } as BiConsumer<String, CacheObject<TestObject>>
+
+        when:
+        cache.evictOldCacheObjects(callback)
+
+        then:
+        evictedKeys.toSet() == ["old1", "old2"] as Set
+        cache.size() == 1
+        cache.get("fresh") != null
+    }
+
+    def "Eviction callback exceptions are swallowed and removal still happens"() {
+        given:
+        cache.setRetentionPeriodInMs(5)
+        cache.put("victim", new TestObject("Grima Ormtunge"), new int[]{})
+        sleep(10)
+
+        BiConsumer<String, CacheObject<TestObject>> exploding =
+                { String k, CacheObject<TestObject> v -> throw new RuntimeException("boom") } as BiConsumer<String, CacheObject<TestObject>>
+
+        when:
+        cache.evictOldCacheObjects(exploding)
+
+        then:
+        noExceptionThrown()
+        cache.size() == 0
+    }
+
 
     def "Remove element from cache"() {
         given:


### PR DESCRIPTION
- Refactor to evictOldCacheObjects
- add overloaded evictOldCacheObjects to Cache interface that requires a BiConsumer<String, CacheObject<T>>
- Overloaded evictOldCacheObjects with BiConsumer<String, CacheObject<T>>